### PR TITLE
Fully functional CRUD for Photos

### DIFF
--- a/internal/api/deletePhoto.go
+++ b/internal/api/deletePhoto.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+
+	db "github.com/AJMerr/little-moments-offline/internal/db"
+	"github.com/AJMerr/little-moments-offline/internal/storage"
+	"gorm.io/gorm"
+)
+
+func DeletePhotoByID(gdb *gorm.DB, s3 *storage.S3) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+
+		var p db.Photo
+		if err := gdb.WithContext(r.Context()).
+			Where("id = ? AND owner_id = ?", id, "local_user"). // DELETE Later, using auth user
+			First(&p).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "db_lookup_failed")
+			return
+		}
+
+		// Soft delete
+		if err := gdb.WithContext(r.Context()).Delete(&p).Error; err != nil {
+			writeError(w, http.StatusInternalServerError, "db_delete_failed")
+			return
+		}
+
+		if err := s3.DeleteObject(r.Context(), s3.Config.BucketPhotos, p.OriginKey); err != nil {
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/api/photoUrl.go
+++ b/internal/api/photoUrl.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	db "github.com/AJMerr/little-moments-offline/internal/db"
+	"github.com/AJMerr/little-moments-offline/internal/storage"
+	"gorm.io/gorm"
+)
+
+func GetPhotoUrl(gdb *gorm.DB, s3 *storage.S3) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+
+		// Photo Lookup
+		var p db.Photo
+		if err := gdb.WithContext(r.Context()).
+			Where("id = ? AND owner_id = ?", id, "local_user"). // DELETE LATER will use Auth
+			First(&p).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				writeError(w, http.StatusNotFound, "not_found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "db_lookup_failed")
+			return
+		}
+
+		_ = r.URL.Query().Get("variant") //
+		key := p.OriginKey
+
+		// TTL
+		ttl := 5 * time.Minute
+		if raw := r.URL.Query().Get("ttl"); raw != "" {
+			if secs, err := strconv.Atoi(raw); err == nil {
+				if secs < 10 {
+					secs = 10
+				}
+				if secs > 3000 {
+					secs = 3000
+				}
+				ttl = time.Duration(secs) * time.Second
+			}
+		}
+
+		url, err := s3.PresignGetObject(r.Context(), s3.Config.BucketPhotos, key, ttl)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "presign_failed")
+			return
+		}
+
+		toJSON(w, http.StatusOK, map[string]any{
+			"url":        url,
+			"expires_at": time.Now().Add(ttl).UTC(),
+		})
+	}
+}

--- a/internal/api/photos.go
+++ b/internal/api/photos.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"mime"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -123,5 +125,110 @@ func ConfirmPhoto(gdb *gorm.DB, s3 *storage.S3) http.HandlerFunc {
 			"bytes": photo.Bytes, "content_type": photo.ContentType,
 			"created_at": photo.CreatedAt,
 		})
+	}
+}
+
+// Makes Created at + id base64 URL encoded
+type cursorPayload struct {
+	T  int64  `json:"t"`
+	ID string `json:"id"`
+}
+
+func encodeCursor(t time.Time, id string) string {
+	b, _ := json.Marshal(cursorPayload{T: t.UnixNano(), ID: id})
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeCursor(s string) (time.Time, string, error) {
+	var p cursorPayload
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return time.Time{}, "", err
+	}
+	if err := json.Unmarshal(b, &p); err != nil {
+		return time.Time{}, "", err
+	}
+	return time.Unix(0, p.T), p.ID, nil
+}
+
+type photoItem struct {
+	ID          string    `json:"id"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	OriginKey   string    `json:"origin_key"`
+	ContentType string    `json:"content_type"`
+	Bytes       int64     `json:"bytes"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type listRes struct {
+	Items      []photoItem `json:"items"`
+	NextCursor string      `json:"next_cursor"`
+}
+
+// Function to GET all photos
+func GetAllPhotos(gdb *gorm.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Limits to 25, clamp 1 - 100
+		limit := 25
+		if s := r.URL.Query().Get("limit"); s != "" {
+			if n, err := strconv.Atoi(s); err == nil {
+				if n < 1 {
+					n = 1
+				}
+				if n > 100 {
+					n = 100
+				}
+				limit = n
+			}
+		}
+
+		// Base query
+		q := gdb.WithContext(r.Context()).
+			Where("owner_id = ?", "local_user"). // REMOVE: will be auth user
+			Order("created_at DESC").
+			Order("id DESC").
+			Limit(limit)
+
+		// If a cursor exists, connect it via WHERE
+		if c := r.URL.Query().Get("curosr"); c != "" {
+			t, lastID, err := decodeCursor(c)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "bad_cursor")
+				return
+			}
+			// Get rows after the last item seen
+			q = q.Where("(created_at < ?) OR (created_at = ? AND id < ?)", t, t, lastID)
+		}
+
+		// Runs query
+		var rows []db.Photo
+		if err := q.Find(&rows).Error; err != nil {
+			writeError(w, http.StatusInternalServerError, "db_list_failed")
+			return
+		}
+
+		// Maps DB rows to API
+		items := make([]photoItem, 0, len(rows))
+		for _, p := range rows {
+			items = append(items, photoItem{
+				ID:          p.ID,
+				Title:       p.Title,
+				Description: p.Description,
+				OriginKey:   p.OriginKey,
+				ContentType: p.ContentType,
+				Bytes:       p.Bytes,
+				CreatedAt:   p.CreatedAt,
+			})
+		}
+
+		// Builds next cursor
+		out := listRes{Items: items}
+		if len(rows) == limit {
+			last := rows[len(rows)-1]
+			out.NextCursor = encodeCursor(last.CreatedAt, last.ID)
+		}
+
+		toJSON(w, http.StatusOK, out)
 	}
 }

--- a/internal/api/photos.go
+++ b/internal/api/photos.go
@@ -232,3 +232,35 @@ func GetAllPhotos(gdb *gorm.DB) http.HandlerFunc {
 		toJSON(w, http.StatusOK, out)
 	}
 }
+
+// Function to GET a photo by ID
+func GetPhotoByID(gdb *gorm.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := r.PathValue("id")
+
+		var p db.Photo
+		err := gdb.WithContext(r.Context()).
+			Where("id = ? AND owner_id = ?", id, "local_user"). /// DELETE Later, will use Auth user
+			First(&p).Error
+
+		if err != nil {
+			if err == gorm.ErrRecordNotFound {
+				writeError(w, http.StatusBadRequest, "photo_not_found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "db_lookup_failed")
+			return
+		}
+
+		out := photoItem{
+			ID:          p.ID,
+			Title:       p.Title,
+			Description: p.Description,
+			OriginKey:   p.OriginKey,
+			ContentType: p.ContentType,
+			Bytes:       p.Bytes,
+			CreatedAt:   p.CreatedAt,
+		}
+		toJSON(w, http.StatusOK, out)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -19,5 +19,6 @@ func RouterHandler(gdb *gorm.DB, s3 *storage.S3) http.Handler {
 	mux.HandleFunc("DELETE /photos/{id}", DeletePhotoByID(gdb, s3))
 	mux.HandleFunc("POST /photos/presign", PresignPhoto(s3))
 	mux.HandleFunc("POST /photos/confirm", ConfirmPhoto(gdb, s3))
+	mux.HandleFunc("PATCH /photos/{id}", UpdatePhoto(gdb))
 	return reqID(logger(panicRecovery(mux)))
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,7 +14,7 @@ func RouterHandler(gdb *gorm.DB, s3 *storage.S3) http.Handler {
 	mux.HandleFunc("GET /version", versionHandler)
 	mux.HandleFunc("GET /panic", func(w http.ResponseWriter, r *http.Request) { panic("AAAAAAHHH BEES") })
 	mux.HandleFunc("GET /photos", GetAllPhotos(gdb))
-	mux.HandleFunc("GET /photos{id}", GetPhotoByID(gdb))
+	mux.HandleFunc("GET /photos/{id}", GetPhotoByID(gdb))
 	mux.HandleFunc("POST /photos/presign", PresignPhoto(s3))
 	mux.HandleFunc("POST /photos/confirm", ConfirmPhoto(gdb, s3))
 	return reqID(logger(panicRecovery(mux)))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -15,6 +15,7 @@ func RouterHandler(gdb *gorm.DB, s3 *storage.S3) http.Handler {
 	mux.HandleFunc("GET /panic", func(w http.ResponseWriter, r *http.Request) { panic("AAAAAAHHH BEES") })
 	mux.HandleFunc("GET /photos", GetAllPhotos(gdb))
 	mux.HandleFunc("GET /photos/{id}", GetPhotoByID(gdb))
+	mux.HandleFunc("GET /photos/{id}/url", GetPhotoUrl(gdb, s3))
 	mux.HandleFunc("POST /photos/presign", PresignPhoto(s3))
 	mux.HandleFunc("POST /photos/confirm", ConfirmPhoto(gdb, s3))
 	return reqID(logger(panicRecovery(mux)))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,6 +14,7 @@ func RouterHandler(gdb *gorm.DB, s3 *storage.S3) http.Handler {
 	mux.HandleFunc("GET /version", versionHandler)
 	mux.HandleFunc("GET /panic", func(w http.ResponseWriter, r *http.Request) { panic("AAAAAAHHH BEES") })
 	mux.HandleFunc("GET /photos", GetAllPhotos(gdb))
+	mux.HandleFunc("GET /photos{id}", GetPhotoByID(gdb))
 	mux.HandleFunc("POST /photos/presign", PresignPhoto(s3))
 	mux.HandleFunc("POST /photos/confirm", ConfirmPhoto(gdb, s3))
 	return reqID(logger(panicRecovery(mux)))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -13,6 +13,7 @@ func RouterHandler(gdb *gorm.DB, s3 *storage.S3) http.Handler {
 	mux.HandleFunc("GET /healthz", healthzHandler)
 	mux.HandleFunc("GET /version", versionHandler)
 	mux.HandleFunc("GET /panic", func(w http.ResponseWriter, r *http.Request) { panic("AAAAAAHHH BEES") })
+	mux.HandleFunc("GET /photos", GetAllPhotos(gdb))
 	mux.HandleFunc("POST /photos/presign", PresignPhoto(s3))
 	mux.HandleFunc("POST /photos/confirm", ConfirmPhoto(gdb, s3))
 	return reqID(logger(panicRecovery(mux)))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -16,6 +16,7 @@ func RouterHandler(gdb *gorm.DB, s3 *storage.S3) http.Handler {
 	mux.HandleFunc("GET /photos", GetAllPhotos(gdb))
 	mux.HandleFunc("GET /photos/{id}", GetPhotoByID(gdb))
 	mux.HandleFunc("GET /photos/{id}/url", GetPhotoUrl(gdb, s3))
+	mux.HandleFunc("DELETE /photos/{id}", DeletePhotoByID(gdb, s3))
 	mux.HandleFunc("POST /photos/presign", PresignPhoto(s3))
 	mux.HandleFunc("POST /photos/confirm", ConfirmPhoto(gdb, s3))
 	return reqID(logger(panicRecovery(mux)))

--- a/internal/api/updatePhoto.go
+++ b/internal/api/updatePhoto.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	db "github.com/AJMerr/little-moments-offline/internal/db"
+	"gorm.io/gorm"
+)
+
+func UpdatePhoto(gdb *gorm.DB) http.HandlerFunc {
+	type patchReq struct {
+		Title       *string `json:"title"`
+		Description *string `json:"description"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		var in patchReq
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request")
+			return
+		}
+		if in.Title == nil && in.Description == nil {
+			writeError(w, http.StatusBadRequest, "missing_fields")
+			return
+		}
+
+		updates := map[string]any{}
+
+		if in.Title != nil {
+			t := strings.TrimSpace(*in.Title)
+			if len(t) > 100 {
+				writeError(w, http.StatusBadRequest, "title_too_long")
+				return
+			}
+			updates["title"] = t
+		}
+
+		if in.Description != nil {
+			d := strings.TrimSpace(*in.Description)
+			if len(d) > 2000 {
+				writeError(w, http.StatusBadRequest, "description_too_long")
+				return
+			}
+			updates["description"] = d
+		}
+
+		if len(updates) == 0 {
+			writeError(w, http.StatusBadRequest, "no_update_made")
+			return
+		}
+
+		id := r.PathValue("id")
+
+		// Only update rows owned by current user
+		tx := gdb.WithContext(r.Context()).
+			Model(&db.Photo{}).
+			Where("id = ? AND owner_id = ?", id, "local_user"). // DELETE THIS, switch to auth user
+			Updates(updates)
+
+		if tx.Error != nil {
+			writeError(w, http.StatusInternalServerError, "db_lookup_failed")
+			return
+		}
+		if tx.RowsAffected == 0 {
+			writeError(w, http.StatusNotFound, "photo_not_found")
+			return
+		}
+
+		// Returns updated metadata
+		var out db.Photo
+		if err := gdb.WithContext(r.Context()).
+			Where("id = ? AND owner_id = ?", id, "local_user"). // YOU KNOW THE DRILL
+			First(&out).Error; err != nil {
+			writeError(w, http.StatusInternalServerError, "db_lookup_failed")
+			return
+		}
+
+		toJSON(w, http.StatusOK, map[string]any{
+			"id":           out.ID,
+			"title":        out.Title,
+			"description":  out.Description,
+			"origin_key":   out.OriginKey,
+			"content_type": out.ContentType,
+			"bytes":        out.Bytes,
+			"created_at":   out.CreatedAt,
+		})
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -28,11 +28,11 @@ type Photo struct {
 }
 
 type Album struct {
-	ID          string `gorm:"primaryKey;type:text"`
-	OwnerID     string `gorm:"index;not null"`
-	Title       string `gorm:"type:text;not null"`
-	Description string `gorm:"type:text"`
-	CreatedAt   time.Time
+	ID          string    `gorm:"primaryKey;type:text"`
+	OwnerID     string    `gorm:"index;not null"`
+	Title       string    `gorm:"type:text;not null"`
+	Description string    `gorm:"type:text"`
+	CreatedAt   time.Time `gorm:"index"`
 
 	Owner  User    `gorm:"constraint:OnDelete:CASCADE;foreignKey:OwnerID;references:ID"`
 	Photos []Photo `gorm:"many2many:album_photos"`

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type User struct {
@@ -22,6 +24,7 @@ type Photo struct {
 	ContentType string `gorm:"not null"`
 	Bytes       int64  `gorm:"not null"`
 	CreatedAt   time.Time
+	DeletedAt   gorm.DeletedAt
 
 	Owner  User    `gorm:"constraint:OnDelete:CASCADE;foreignKey:OwnerID;references:ID"`
 	Albums []Album `gorm:"many2many:album_photos"`

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -68,6 +68,20 @@ func (s *S3) PresignPut(ctx context.Context, bucket, key, contentType string, ex
 	return out.URL, map[string]string{"Content-Type": contentType}, nil
 }
 
+// Confirms an object exists in MinIO
 func (s *S3) Head(ctx context.Context, bucket, key string) (*s3.HeadObjectOutput, error) {
 	return s.raw.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &bucket, Key: &key})
+}
+
+// Funtion returns a time limited URL to read an object
+func (s *S3) PresignGetObject(ctx context.Context, bucket, key string, ttl time.Duration) (string, error) {
+	p := s3.NewPresignClient(s.raw)
+	out, err := p.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	}, func(o *s3.PresignOptions) { o.Expires = ttl })
+	if err != nil {
+		return "", nil
+	}
+	return out.URL, nil
 }

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -85,3 +85,12 @@ func (s *S3) PresignGetObject(ctx context.Context, bucket, key string, ttl time.
 	}
 	return out.URL, nil
 }
+
+// Function to delete a photo by ID
+func (s *S3) DeleteObject(ctx context.Context, bucket, key string) error {
+	_, err := s.raw.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	return err
+}


### PR DESCRIPTION
I have implemented the following:

- CREATE
- READ
- UPDATE
- DELETE

All endpoints have been tested and verified to work. 

On CREATE, presigned URL is generated via API call. Then /photo/confirm validates that the image exists in blob. Finally, the DB is updated with metadata. 