### PR TITLE
Fix for inherent DB ownership

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# -------- MinIO bootstrap creds (used by the minio service) --------
+# NOTE: If your password contains a dollar sign, ESCAPE each $ as $$ in this file.
+# Example: Pa$$word123  ->  Pa$$$$word123
+MINIO_ROOT_USER=miniadmin
+MINIO_ROOT_PASSWORD=Pa$$$$word123
+
+# -------- API settings (compose injects these into the api service) --------
+# Origins allowed to call the API (comma-separated). Keep both for local dev.
+LM_WEB_ORIGINS=http://localhost:8080,http://littlemoments:8080
+
+# Photos bucket name (created automatically on first run if missing).
+LM_S3_BUCKET_PHOTOS=photos
+
+# If you serve files directly from MinIO (no Caddy /s3 proxy), set a public base.
+# Example: http://localhost:9000   (leave blank when using the /s3 proxy from the web image)
+LM_S3_PUBLIC_BASE=
+
+# ---- Optional: only needed when running the API OUTSIDE docker-compose ----
+# LM_S3_ENDPOINT=http://localhost:9000
+# LM_S3_REGION=us-east-1
+# LM_S3_ACCESS_KEY=${MINIO_ROOT_USER}
+# LM_S3_SECRET_KEY=${MINIO_ROOT_PASSWORD}
+# LM_ADDR=:8173            # API listen address (default is :8173)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN go build -o /bin/api ./cmd/api
 #---Runtime Stage---
 FROM alpine:3.20
 RUN adduser -D -H -u 10001 app
+RUN mkdir -p /app/data
 WORKDIR /app
 COPY --from=build /bin/api /usr/local/bin/api
 EXPOSE 8173

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,7 +31,7 @@ services:
       LM_S3_PUBLIC_BASE: http://localhost:9000
       LM_WEB_ORIGINS: http://localhost:8080
     volumes:
-      - ./data:/app/data             
+      - app_data:/app/data             
     depends_on:
       - minio
 
@@ -48,4 +48,5 @@ services:
       - minio_data:/data
 
 volumes:
+  app_data:
   minio_data:

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,5 @@
+# When the web container proxies /api/* to the API
+VITE_API_BASE=/api
+
+# Use this if you plan on removing the proxy
+# VITE_API_BASE=http://127.0.0.1:8173


### PR DESCRIPTION
Modified how the volumes work so that ownership is inherent rather than an end user needing to create an app user and chown and chmod a ./data